### PR TITLE
Fix No Ramdisk found for Non-Slot but init_boot devices.

### DIFF
--- a/anykernel.sh
+++ b/anykernel.sh
@@ -44,7 +44,7 @@ ui_print " " "  -> ksu_supported: $ksu_supported"
 $ksu_supported || abort "  -> Non-GKI device, abort."
 
 # boot install
-if [ -L "/dev/block/bootdevice/by-name/init_boot_a" -o -L "/dev/block/by-name/init_boot_a" ]; then
+if [ -L "/dev/block/bootdevice/by-name/init_boot_a" -o -L "/dev/block/by-name/init_boot_a" -o -L "/dev/block/bootdevice/by-name/init_boot" -o -L "/dev/block/by-name/init_boot" ]; then
     split_boot # for devices with init_boot ramdisk
     flash_boot # for devices with init_boot ramdisk
 else


### PR DESCRIPTION
This fixes the issue for Samsung devices like Samsung S24 devices and other devices.

shell: su -c ls -la /dev/block/bootdevice/by-name/init_boot* 
< lrwxrwxrwx 1 root root 16 1970-12-19 22:58 /dev/block/bootdevice/by-name/init_boot -> /dev/block/sda28 
shell: su -c ls -la /dev/block/bootdevice/by-name/boot* 
< lrwxrwxrwx 1 root root 16 1970-12-19 22:58 /dev/block/bootdevice/by-name/boot -> /dev/block/sda27