### PR TITLE
feat(anykernel): add kernel version compatibility check before flash

### DIFF
--- a/anykernel.sh
+++ b/anykernel.sh
@@ -10,6 +10,7 @@ do.modules=0
 do.systemless=0
 do.cleanup=1
 do.cleanuponabort=0
+do.check_boot_version=1
 device.name1=
 device.name2=
 device.name3=
@@ -32,6 +33,7 @@ no_magisk_check=1
 # import functions/variables and setup patching - see for reference (DO NOT REMOVE)
 . tools/ak3-core.sh
 
+# GKI check
 kernel_version=$(cat /proc/version | awk -F '-' '{print $1}' | awk '{print $3}')
 case $kernel_version in
     5.1*) ksu_supported=true ;;
@@ -43,9 +45,92 @@ esac
 ui_print " " "  -> Wild Kernels Supported: $ksu_supported"
 $ksu_supported || abort "  -> Non-GKI device, abort."
 
+# Kernel version extraction function from kernel files (raw or compressed)
+# Returns only X.X.X-androidYY, discards everything else
+extract_kernel_version() {
+  local target="$1"
+  local ver_str tmpfile
+
+  # Attempt 1: raw (direct strings) - single grep extracts X.X.X-androidYY directly
+  ver_str=$(strings "$target" 2>/dev/null | grep -oE 'Linux version [0-9]+\.[0-9]+\.[0-9]+-android[0-9]+' -m1 | cut -d' ' -f3)
+
+  # Attempt 2: compressed kernel → magiskboot decompress then strings
+  if [ -z "$ver_str" ]; then
+    tmpfile="${target}_ak3decomp"
+    magiskboot decompress "$target" "$tmpfile" 2>/dev/null
+    if [ -f "$tmpfile" ]; then
+      ver_str=$(strings "$tmpfile" 2>/dev/null | grep -oE 'Linux version [0-9]+\.[0-9]+\.[0-9]+-android[0-9]+' -m1 | cut -d' ' -f3)
+      rm -f "$tmpfile"
+    fi
+  fi
+
+  echo "$ver_str"
+}
+
+# Version comparison: returns 0 if a >= b, 1 if a < b
+version_ge() {
+  if [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Kernel Version Check Function: Image vs. Kernel in Device
+# Runs before split_boot: reads device kernel version directly from $BLOCK
+do_kernelcheck() {
+  ui_print " " "  -> Check kernel version compatibility..."
+
+  # BYPASS: do.check_boot_version=0 in anykernel.sh skips check
+  if [ "$(file_getprop anykernel.sh do.check_boot_version)" != 1 ]; then
+    ui_print "  -> [BYPASS] do.check_boot_version=0: version check SKIPPED."
+    ui_print "  -> [BYPASS] Forced flash. Proceed with caution!"
+    return 0
+  fi
+
+  local new_ver dev_ver new_kver new_abranch dev_kver dev_abranch
+
+  # Version from Image file (new kernel to flash)
+  new_ver=$(extract_kernel_version "$AKHOME/Image")
+  if [ -z "$new_ver" ]; then
+    abort "  -> ERROR: Unable to read version from Image. Abort."
+  fi
+
+  # Version from device boot partition (target slot, direct read via $BLOCK)
+  dev_ver=$(extract_kernel_version "$BLOCK")
+  if [ -z "$dev_ver" ]; then
+    abort "  -> ERROR: Unable to read version from device boot partition. Abort."
+  fi
+
+  # Split X.X.X and androidYY
+  new_kver=$(echo "$new_ver" | cut -d- -f1)
+  new_abranch=$(echo "$new_ver" | cut -d- -f2)
+  dev_kver=$(echo "$dev_ver" | cut -d- -f1)
+  dev_abranch=$(echo "$dev_ver" | cut -d- -f2)
+
+  ui_print "  -> Image  : $new_ver"
+  ui_print "  -> Device : $dev_ver"
+
+  # Check 1: android branch must be exactly equal
+  if [ "$new_abranch" != "$dev_abranch" ]; then
+    abort "  -> MISMATCH Android branch: Image=$new_abranch | Device=$dev_abranch. Abort."
+  fi
+
+  # Check 2: kernel version Image must be >= Device
+  if ! version_ge "$new_kver" "$dev_kver"; then
+    abort "  -> MISMATCH Kernel version: Image=$new_kver < Device=$dev_kver. Abort."
+  fi
+
+  ui_print "  -> Kernel version: COMPATIBLE ($new_ver >= $dev_ver)"
+}
+
+# Check: runs before split_boot, reads device kernel version directly from $BLOCK
+do_kernelcheck
+
 # boot install
 split_boot
-if [ -f "split_img/ramdisk.cpio" ]; then
+
+if [ -f "$SPLITIMG/ramdisk.cpio" ]; then
     unpack_ramdisk
     write_boot
 else

--- a/anykernel.sh
+++ b/anykernel.sh
@@ -10,7 +10,7 @@ do.modules=0
 do.systemless=0
 do.cleanup=1
 do.cleanuponabort=0
-do.check_boot_version=1
+do.check_boot_version=0
 device.name1=
 device.name2=
 device.name3=
@@ -44,88 +44,6 @@ esac
 
 ui_print " " "  -> Wild Kernels Supported: $ksu_supported"
 $ksu_supported || abort "  -> Non-GKI device, abort."
-
-# Kernel version extraction function from kernel files (raw or compressed)
-# Returns only X.X.X-androidYY, discards everything else
-extract_kernel_version() {
-  local target="$1"
-  local ver_str tmpfile
-
-  # Attempt 1: raw (direct strings) - single grep extracts X.X.X-androidYY directly
-  ver_str=$(strings "$target" 2>/dev/null | grep -oE 'Linux version [0-9]+\.[0-9]+\.[0-9]+-android[0-9]+' -m1 | cut -d' ' -f3)
-
-  # Attempt 2: compressed kernel → magiskboot decompress then strings
-  if [ -z "$ver_str" ]; then
-    tmpfile="${target}_ak3decomp"
-    magiskboot decompress "$target" "$tmpfile" 2>/dev/null
-    if [ -f "$tmpfile" ]; then
-      ver_str=$(strings "$tmpfile" 2>/dev/null | grep -oE 'Linux version [0-9]+\.[0-9]+\.[0-9]+-android[0-9]+' -m1 | cut -d' ' -f3)
-      rm -f "$tmpfile"
-    fi
-  fi
-
-  echo "$ver_str"
-}
-
-# Version comparison: returns 0 if a >= b, 1 if a < b
-version_ge() {
-  if [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-# Kernel Version Check Function: Image vs. Kernel in Device
-# Runs before split_boot: reads device kernel version directly from $BLOCK
-do_kernelcheck() {
-  ui_print " " "  -> Check kernel version compatibility..."
-
-  # BYPASS: do.check_boot_version=0 in anykernel.sh skips check
-  if [ "$(file_getprop anykernel.sh do.check_boot_version)" != 1 ]; then
-    ui_print "  -> [BYPASS] do.check_boot_version=0: version check SKIPPED."
-    ui_print "  -> [BYPASS] Forced flash. Proceed with caution!"
-    return 0
-  fi
-
-  local new_ver dev_ver new_kver new_abranch dev_kver dev_abranch
-
-  # Version from Image file (new kernel to flash)
-  new_ver=$(extract_kernel_version "$AKHOME/Image")
-  if [ -z "$new_ver" ]; then
-    abort "  -> ERROR: Unable to read version from Image. Abort."
-  fi
-
-  # Version from device boot partition (target slot, direct read via $BLOCK)
-  dev_ver=$(extract_kernel_version "$BLOCK")
-  if [ -z "$dev_ver" ]; then
-    abort "  -> ERROR: Unable to read version from device boot partition. Abort."
-  fi
-
-  # Split X.X.X and androidYY
-  new_kver=$(echo "$new_ver" | cut -d- -f1)
-  new_abranch=$(echo "$new_ver" | cut -d- -f2)
-  dev_kver=$(echo "$dev_ver" | cut -d- -f1)
-  dev_abranch=$(echo "$dev_ver" | cut -d- -f2)
-
-  ui_print "  -> Image  : $new_ver"
-  ui_print "  -> Device : $dev_ver"
-
-  # Check 1: android branch must be exactly equal
-  if [ "$new_abranch" != "$dev_abranch" ]; then
-    abort "  -> MISMATCH Android branch: Image=$new_abranch | Device=$dev_abranch. Abort."
-  fi
-
-  # Check 2: kernel version Image must be >= Device
-  if ! version_ge "$new_kver" "$dev_kver"; then
-    abort "  -> MISMATCH Kernel version: Image=$new_kver < Device=$dev_kver. Abort."
-  fi
-
-  ui_print "  -> Kernel version: COMPATIBLE ($new_ver >= $dev_ver)"
-}
-
-# Check: runs before split_boot, reads device kernel version directly from $BLOCK
-do_kernelcheck
 
 # boot install
 split_boot

--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -978,10 +978,31 @@ extract_kernel_version() {
 }
 
 # Version comparison: returns 0 if a >= b, 1 if a < b
+Bash
+
+
 version_ge() {
-  if [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]; then
+  local new=$1 dev=$2
+  local n1 n2 n3 d1 d2 d3
+  
+  # Fast-track for exact matches (5.15.180 == 5.15.180)
+  [ "$new" = "$dev" ] && return 0
+
+  # Split into segments
+  n1=$(echo "$new" | cut -d. -f1); n2=$(echo "$new" | cut -d. -f2); n3=$(echo "$new" | cut -d. -f3)
+  d1=$(echo "$dev" | cut -d. -f1); d2=$(echo "$dev" | cut -d. -f2); d3=$(echo "$dev" | cut -d. -f3)
+
+  # Check Major & Minor equality
+  if [ "$n1" != "$d1" ] || [ "$n2" != "$d2" ]; then
+    ui_print "  -> ERROR: Base version mismatch ($n1.$n2 vs $d1.$d2)"
+    return 1
+  fi
+
+  # Check Patch version (e.g., .185 >= .180)
+  if [ "$n3" -ge "$d3" ] 2>/dev/null; then
     return 0
   else
+    ui_print "  -> ERROR: Downgrade detected ($n3 < $d3)"
     return 1
   fi
 }

--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -955,7 +955,86 @@ setup_ak() {
   type ${name}_attributes >/dev/null 2>&1 && ${name}_attributes;
 }
 ###
+# Kernel version extraction function from kernel files (raw or compressed)
+# Returns only X.X.X-androidYY, discards everything else
+extract_kernel_version() {
+  local target="$1"
+  local ver_str tmpfile
+
+  # Attempt 1: raw (direct strings) - single grep extracts X.X.X-androidYY directly
+  ver_str=$(strings "$target" 2>/dev/null | grep -oE 'Linux version [0-9]+\.[0-9]+\.[0-9]+-android[0-9]+' -m1 | cut -d' ' -f3)
+
+  # Attempt 2: compressed kernel → magiskboot decompress then strings
+  if [ -z "$ver_str" ]; then
+    tmpfile="${target}_ak3decomp"
+    magiskboot decompress "$target" "$tmpfile" 2>/dev/null
+    if [ -f "$tmpfile" ]; then
+      ver_str=$(strings "$tmpfile" 2>/dev/null | grep -oE 'Linux version [0-9]+\.[0-9]+\.[0-9]+-android[0-9]+' -m1 | cut -d' ' -f3)
+      rm -f "$tmpfile"
+    fi
+  fi
+
+  echo "$ver_str"
+}
+
+# Version comparison: returns 0 if a >= b, 1 if a < b
+version_ge() {
+  if [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Kernel Version Check Function: Image vs. Kernel in Device
+do_check_boot_version() {
+  ui_print " " "  -> Check kernel version compatibility..."
+
+  # BYPASS: do.check_boot_version=0 in anykernel.sh skips check
+  if [ "$(file_getprop anykernel.sh do.check_boot_version)" != 1 ]; then
+    ui_print "  -> [BYPASS] do.check_boot_version=0: version check SKIPPED."
+    ui_print "  -> [BYPASS] Forced flash. Proceed with caution!"
+    return 1
+  fi
+
+  local new_ver dev_ver new_kver new_abranch dev_kver dev_abranch
+
+  # Version from Image file (new kernel to flash)
+  new_ver=$(extract_kernel_version "$AKHOME/Image")
+  if [ -z "$new_ver" ]; then
+    abort "  -> ERROR: Unable to read version from Image. Abort."
+  fi
+
+  # Version from device boot partition (target slot, direct read via $BLOCK)
+  dev_ver=$(extract_kernel_version "$BLOCK")
+  if [ -z "$dev_ver" ]; then
+    abort "  -> ERROR: Unable to read version from device boot partition. Abort."
+  fi
+
+  # Split X.X.X and androidYY
+  new_kver=$(echo "$new_ver" | cut -d- -f1)
+  new_abranch=$(echo "$new_ver" | cut -d- -f2)
+  dev_kver=$(echo "$dev_ver" | cut -d- -f1)
+  dev_abranch=$(echo "$dev_ver" | cut -d- -f2)
+
+  ui_print "  -> Image  : $new_ver"
+  ui_print "  -> Device : $dev_ver"
+
+  # Check 1: android branch must be exactly equal
+  if [ "$new_abranch" != "$dev_abranch" ]; then
+    abort "  -> MISMATCH Android branch: Image=$new_abranch | Device=$dev_abranch. Abort."
+  fi
+
+  # Check 2: kernel version Image must be >= Device
+  if ! version_ge "$new_kver" "$dev_kver"; then
+    abort "  -> MISMATCH Kernel version: Image=$new_kver < Device=$dev_kver. Abort."
+  fi
+
+  ui_print "  -> Kernel version: COMPATIBLE ($new_ver >= $dev_ver)"
+}
 
 ### end methods
 
 setup_ak;
+
+do_check_boot_version;


### PR DESCRIPTION
- Extract kernel version (X.X.X-androidYY only) from Image and $BLOCK
  via extract_kernel_version(), with fallback to magiskboot decompress
- Single grep -oE -m1 extracts version directly
- version_ge() uses sort -V for clean semantic version comparison
- Check 1: android branch must match exactly (any mismatch, Abort)
- Check 2: kernel version Image must be >= Device (Image < Device, Abort)
- Add do.check_boot_version property (1=check active, 0=skip check)
- Check runs before split_boot, before flash_boot/write_boot

Output examples:
  -> Image  : 5.10.236-android12 
  -> Device : 5.10.236-android12 
  -> Kernel version: COMPATIBLE (5.10.236-android12 >= 5.10.236-android12)

  -> MISMATCH Kernel version: Image=5.10.235 < Device=5.10.236. Abort.
  -> MISMATCH Android branch: Image=android12 | Device=android15. Abort.

Bypass usage:
  set do.check_boot_version=0 in anykernel.sh properties